### PR TITLE
Add 'layout' option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import { DEFAULT_PATH_FORMATTER } from "./constants";
  * @param {function} props.createPage - reference to Gatsby's {@link https://www.gatsbyjs.org/docs/bound-action-creators/#createPage|createPage} method
  * @param {Array.<Object>} props.edges - collection of data nodes
  * @param {string} props.component - The absolute path to the component used for each page
+ * @param {string} [props.layout] The name of the layout for this page. By default `'index'` layout is used
  * @param {number} [props.limit=10] - the posts per page limit
  * @param {pathFormatter} [props.pathFormatter=DEFAULT_PATH_FORMATTER] - the formatter to use when generating page paths
  * @param {Object} [props.context] - the context data to pass to pageCreate, See [Gatsby documentation]@link{https://www.gatsbyjs.org/docs/bound-action-creators/#createPage}
@@ -42,11 +43,20 @@ import { DEFAULT_PATH_FORMATTER } from "./constants";
  * });
  */
 export function createPaginationPages(props) {
-  const { createPage, edges, component, limit, pathFormatter, context } = props;
+  const {
+    createPage,
+    edges,
+    component,
+    layout,
+    limit,
+    pathFormatter,
+    context
+  } = props;
   const paginationPageBuilder = new PaginationPageBuilder(
     createPage,
     edges,
-    component
+    component,
+    layout
   );
   if (limit) paginationPageBuilder.setLimit(limit);
   if (pathFormatter) paginationPageBuilder.setPathFormatter(pathFormatter);

--- a/src/pagination-page-builder.js
+++ b/src/pagination-page-builder.js
@@ -46,7 +46,7 @@ const hasNextPage = (index, pages) => index + 1 < pages.length;
  * [Gatsby's createPage documentation]{@link https://www.gatsbyjs.org/docs/bound-action-creators/#createPage}
  */
 class PaginationPageBuilder {
-  constructor(createPage, edges, component) {
+  constructor(createPage, edges, component, layout) {
     if (!createPage) throw Error("Argument `createPage` must be provided.");
     if (!edges) throw Error("Argument `edges` must be provided.");
     if (!component) throw Error("Argument `component` must be provided.");
@@ -54,6 +54,7 @@ class PaginationPageBuilder {
     this.createPage = createPage;
     this.edges = edges;
     this.component = component;
+    this.layout = layout;
     this.limit = constants.DEFAULT_LIMIT;
     this.pathFormatter = constants.DEFAULT_PATH_FORMATTER;
     this.context = {};
@@ -121,6 +122,7 @@ class PaginationPageBuilder {
         return this.createPage({
           path: this.pathFormatter(pageNumber),
           component: this.component,
+          layout: this.layout,
           context: context
         });
       }


### PR DESCRIPTION
`createPage` method accepts also an optional `layout` param to specify which layout is supposed to be used to when generating a page. This PR simply passes this param to `createPage`, similarly to `component`.