### PR TITLE
Bugfix & prettier format example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,14 @@ paths.
 
 See the [createPaginatePages](https://infinitedescent.github.io/gatsby-pagination/#createpaginationpages) documentation for more details.
 
-```js
-exports.createPages = ({ graphql, boundActionCreators }) => {
+```jsexports.createPages = ({ graphql, boundActionCreators }) => {
   const { createPage } = boundActionCreators;
 
   return new Promise((resolve, reject) => {
     const indexPage = path.resolve("src/components/index.jsx");
     const postPage = path.resolve("src/components/post.jsx");
     resolve(
-      graphql(
-        `add GraphQL query`
-      ).then(result => {
+      graphql(`add GraphQL query`).then(result => {
         if (result.errors) {
           reject(result.errors);
         }
@@ -67,18 +64,17 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
           limit: 5
         });
 
-          createPage({
-            path: edge.node.id,
-            component: postPage,
-            context: {
-              slug: edge.node.fields.slug
-            }
-          });
+        createPage({
+          path: edge.node.id,
+          component: postPage,
+          context: {
+            slug: edge.node.fields.slug
+          }
         });
       })
     );
   });
-};
+};  
 ```
 
 ### Create the index.js component


### PR DESCRIPTION
There was a minor typo (double `});`) in the example code, and the indentation was wonky. I fixed the typo and formatted it with prettier so the indentation is clean. Makes it a little more readable I reckon.

PS> Thanks for sharing this package.